### PR TITLE
Bug fix: avoid exception when there is a NULL in a table.

### DIFF
--- a/sqlitemagic.py
+++ b/sqlitemagic.py
@@ -52,6 +52,7 @@ class SqliteMagic(Magics):
         return '<table>\n' + header_row + '\n'.join(self.rowify(r) for r in rows) + '\n</table>'
 
     def rowify(self, row):
+        row = list(row)
         for i, r in enumerate(row):
             if r is None:
                 row[i] = "NULL"


### PR DESCRIPTION
Existing code was trying to change an entry in a tuple (which is immutable) with "NULL", causing an exception. Fix by converting to a list at the beginning of the rowify function.

Did this work before? Maybe in a different environment the row was a list rather than a tuple.
